### PR TITLE
Migrate to domjudge 8.x

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,341 @@
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Library General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+	    How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+    MA  02110-1301, USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Library General
+Public License instead of this License.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@
 $ composer install
 ```
 
-Such a piece of SQL should be executed first.
+## Running
 
-```sql
-ALTER TABLE balloon ADD COLUMN printed tinyint(1) unsigned NOT NULL DEFAULT '0' COMMENT 'Has been printed?';
+Add credentials for API to `~/.netrc` like `default login admin password adm1n`.
+
+Run the script like:
+
+```bash
+php main.php http://localhost/domjudge
 ```

--- a/lib/lib.error.php
+++ b/lib/lib.error.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types=1);
+/**
+ * Error handling functions
+ *
+ * Part of the DOMjudge Programming Contest Jury System and licensed
+ * under the GNU GPL. See README and COPYING for details.
+ */
+if (! defined('SCRIPT_ID')) {
+    define('SCRIPT_ID', basename($_SERVER['PHP_SELF'], '.php'));
+}
+
+// Default verbosity and loglevels:
+$verbose  = LOG_NOTICE;
+$loglevel = LOG_DEBUG;
+
+// Open standard error:
+if (!defined('STDERR')) {
+    define('STDERR', fopen('php://stderr', 'w'));
+}
+
+// Open log file:
+if (defined('LOGFILE')) {
+    if ($fp = @fopen(LOGFILE, 'a')) {
+        define('STDLOG', $fp);
+    } else {
+        fwrite(STDERR, "Cannot open log file " . LOGFILE .
+            " for appending; continuing without logging.\n");
+    }
+    unset($fp);
+}
+
+// Open syslog connection:
+if (defined('SYSLOG')) {
+    if (!openlog(SCRIPT_ID, LOG_NDELAY | LOG_PID | LOG_CONS, SYSLOG)) {
+        error("cannot open syslog");
+    }
+}
+
+/**
+ * Log a message $string on the loglevel $msglevel.
+ * Prepends a timestamp and log to the logfile.
+ * If this is the web interface: write to the screen with the right CSS class.
+ * If this is the command line: write to Standard Error.
+ */
+function logmsg(int $msglevel, string $string)
+{
+    global $verbose, $loglevel;
+
+    // Trim $string to reasonable length
+    $string = substr($string, 0, 10000);
+
+    $msec = sprintf("%03d", (int)(explode(' ', microtime())[0]*1000));
+    $stamp = "[" . date('M d H:i:s') . ".$msec] " . SCRIPT_ID .
+        (function_exists('posix_getpid') ? "[" . posix_getpid() . "]" : "") .
+        ": ";
+
+    if ($msglevel <= $verbose) {
+        fwrite(STDERR, $stamp . $string . "\n");
+        fflush(STDERR);
+    }
+    if ($msglevel <= $loglevel) {
+        if (defined('STDLOG')) {
+            fwrite(STDLOG, $stamp . $string . "\n");
+            fflush(STDLOG);
+        }
+        if (defined('SYSLOG')) {
+            // Remove the ANSI escape characters,
+            // When logging direct to the terminal the checkmark should be green, this
+            // does not work in log so remove this specific control char.
+            // This removes both the start and the reset of the color.
+            syslog($msglevel, preg_replace('# ?\\x1b\[[0-9];?[0-9]*m#', '', $string) . "\n");
+        }
+    }
+}
+
+/**
+ * Log an error at level LOG_ERROR and exit with exitcode 1.
+ */
+function error(string $string)
+{
+    logmsg(LOG_ERR, "error: $string");
+    exit(1);
+}
+
+/**
+ * Log a warning at level LOG_WARNING.
+ */
+function warning(string $string)
+{
+    logmsg(LOG_WARNING, "warning: $string");
+}
+
+/**
+ * Write debugging output using var_dump(). Uses <pre> in web context.
+ */
+function debug()
+{
+    if (DEBUG===0) {
+        return;
+    }
+
+    call_user_func_array('var_dump', func_get_args());
+}
+
+/**
+ * Handle exceptions by calling error().
+ */
+function exception_handler(Throwable $e)
+{
+    error($e->getMessage() . ( (defined('DEBUG') && DEBUG) ? " in " . $e->getFile() . " line " . $e->getLine() : ''));
+}
+
+set_exception_handler('exception_handler');

--- a/lib/lib.misc.php
+++ b/lib/lib.misc.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types=1);
+/**
+ * Miscellaneous helper functions
+ *
+ * Part of the DOMjudge Programming Contest Jury System and licensed
+ * under the GNU GPL. See README and COPYING for details.
+ */
+
+require_once('lib.wrappers.php');
+
+/**
+ * Calculate timelimit overshoot from actual timelimit and configured
+ * overshoot that can be specified as a sum,max,min of absolute and
+ * relative times. Returns overshoot seconds as a float.
+ */
+function overshoot_time(float $timelimit, string $overshoot_cfg) : float
+{
+    $tokens = preg_split('/([+&|])/', $overshoot_cfg, -1, PREG_SPLIT_DELIM_CAPTURE);
+    if (count($tokens)!=1 && count($tokens)!=3) {
+        error("invalid timelimit overshoot string '$overshoot_cfg'");
+    }
+
+    $val1 = overshoot_parse($timelimit, $tokens[0]);
+    if (count($tokens)==1) {
+        return $val1;
+    }
+
+    $val2 = overshoot_parse($timelimit, $tokens[2]);
+    switch ($tokens[1]) {
+        case '+':
+            return $val1 + $val2;
+        case '|':
+            return max($val1, $val2);
+        case '&':
+            return min($val1, $val2);
+    }
+    error("invalid timelimit overshoot string '$overshoot_cfg'");
+}
+
+/**
+ * Helper function for overshoot_time(), returns overshoot for single token.
+ */
+function overshoot_parse(float $timelimit, string $token) : float
+{
+    $res = sscanf($token, '%d%c%n');
+    if (count($res)!=3) {
+        error("invalid timelimit overshoot token '$token'");
+    }
+    list($val, $type, $len) = $res;
+    if (strlen($token)!=$len) {
+        error("invalid timelimit overshoot token '$token'");
+    }
+
+    if ($val<0) {
+        error("timelimit overshoot cannot be negative: '$token'");
+    }
+    switch ($type) {
+        case 's':
+            return $val;
+        case '%':
+            return $timelimit * 0.01*$val;
+        default:
+            error("invalid timelimit overshoot token '$token'");
+    }
+}
+
+/**
+ * Call alert plugin program to perform user configurable action on
+ * important system events. See default alert script for more details.
+ */
+function alert(string $msgtype, string $description = '')
+{
+    system(LIBDIR . "/alert '$msgtype' '$description' &");
+}
+
+/**
+ * Functions to support graceful shutdown of daemons upon receiving a signal
+ */
+function sig_handler(int $signal, $siginfo = null)
+{
+    global $exitsignalled, $gracefulexitsignalled;
+
+    logmsg(LOG_DEBUG, "Signal $signal received");
+
+    switch ($signal) {
+        case SIGHUP:
+            $gracefulexitsignalled = true;
+            // no break
+        case SIGINT:   # Ctrl+C
+        case SIGTERM:
+            $exitsignalled = true;
+    }
+}
+
+function initsignals()
+{
+    global $exitsignalled;
+
+    $exitsignalled = false;
+
+    if (! function_exists('pcntl_signal')) {
+        logmsg(LOG_INFO, "Signal handling not available");
+        return;
+    }
+
+    logmsg(LOG_DEBUG, "Installing signal handlers");
+
+    // Install signal handler for TERMINATE, HANGUP and INTERRUPT
+    // signals. The sleep() call will automatically return on
+    // receiving a signal.
+    pcntl_signal(SIGTERM, "sig_handler");
+    pcntl_signal(SIGHUP, "sig_handler");
+    pcntl_signal(SIGINT, "sig_handler");
+}
+
+/**
+ * Output generic version information and exit.
+ */
+function version() : string
+{
+    echo SCRIPT_ID . " -- part of DOMjudge version " . DOMJUDGE_VERSION . "\n" .
+        "Written by the DOMjudge developers\n\n" .
+        "DOMjudge comes with ABSOLUTELY NO WARRANTY.  This is free software, and you\n" .
+        "are welcome to redistribute it under certain conditions.  See the GNU\n" .
+        "General Public Licence for details.\n";
+    exit(0);
+}

--- a/lib/lib.wrappers.php
+++ b/lib/lib.wrappers.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types=1);
+/**
+ * Miscellaneous wrappers for PHP functions, included from lib.misc.php.
+ *
+ * Part of the DOMjudge Programming Contest Jury System and licensed
+ * under the GNU GPL. See README and COPYING for details.
+ */
+
+/**
+ * Decode a JSON string with our preferred settings.
+ */
+function dj_json_decode(string $str)
+{
+    return json_decode($str, true, 512, JSON_THROW_ON_ERROR);
+}
+
+/**
+ * Try to decode a JSON string with our preferred settings.
+ * Does not throw error, but errors can be obtained via json_last_error().
+ */
+function dj_json_try_decode(string $str)
+{
+    return json_decode($str, true);
+}
+
+/**
+ * Encode data to JSON with our preferred settings.
+ */
+function dj_json_encode($data) : string
+{
+    return json_encode($data, JSON_PRESERVE_ZERO_FRACTION | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+}
+
+/**
+ * Helperfunction to read all contents from a file.
+ * If $maxsize is set to a nonnegative integer, then limit data read
+ * to this many bytes, and when the truncating the file, attach a note
+ * saying so.
+ */
+function dj_file_get_contents(string $filename, int $maxsize = -1) : string
+{
+    if (! file_exists($filename)) {
+        error("File does not exist: $filename");
+    }
+    if (! is_readable($filename)) {
+        error("File is not readable: $filename");
+    }
+
+    if ($maxsize >= 0 && filesize($filename) > $maxsize) {
+        $res = file_get_contents($filename, false, null, 0, $maxsize);
+        if ($res===false) {
+            error("Error reading from file: $filename");
+        }
+        $res .= "\n[output storage truncated after $maxsize B]\n";
+    } else {
+        $res = file_get_contents($filename);
+        if ($res===false) {
+            error("Error reading from file: $filename");
+        }
+    }
+
+    return $res;
+}
+
+/**
+ * Fix broken behaviour of escapeshellarg that it doesn't return '' for an
+ * empty string.
+ */
+function dj_escapeshellarg(?string $arg) : string
+{
+    if (!isset($arg) || $arg==='') {
+        return "''";
+    }
+    return escapeshellarg($arg);
+}
+
+/**
+ * A simple function that allows to sleep for fractional seconds. Note that
+ * usleep is documented to consume CPU cycles and may not work for times
+ * larger than a second.
+ * Returns a boolean value for success or if the delay was interrupted by a
+ * signal, returns a float with the time remaining, similar to time_nanosleep.
+ */
+function dj_sleep(float $seconds)
+{
+    $second_in_nanoseconds = 1_000_000_000;
+
+    $seconds_int = (int)$seconds;
+    $nanoseconds = (int)($second_in_nanoseconds * ($seconds-$seconds_int));
+
+    $result = time_nanosleep($seconds_int, $nanoseconds);
+    if (is_array($result)) {
+        $result = $result['seconds'] + $result['nanoseconds'] / $second_in_nanoseconds;
+    }
+
+    return $result;
+}

--- a/main.php
+++ b/main.php
@@ -1,8 +1,18 @@
 <?php declare(strict_types=1);
 /**
+ * @configure_input@
+ *
  * Notify contest crew when there is a new, correct submission (for
- * which a balloon has to be handed out). Alternatively there's also
- * a web based tool in the jury interface.
+ * which a balloon has to be handed out).
+ *
+ * This is only needed when not using the web based tool in the jury
+ * interface of DOMjudge. This daemon and that tool cannot be used
+ * at the same time.
+ *
+ * Usage:
+ *  ./balloons https://example.org/domjudge
+ * with your .netrc file containing the required credentials with at
+ * least the 'balloon runner' role.
  *
  * Part of the DOMjudge Programming Contest Jury System and licensed
  * under the GNU GPL. See README and COPYING for details.
@@ -13,62 +23,140 @@ if (isset($_SERVER['REMOTE_ADDR'])) {
     die("Commandline use only");
 }
 
-require('/home/ubuntu/domjudge/domserver/etc/domserver-static.php'); // change it to your domjudge etc
-require(ETCDIR . '/domserver-config.php');
+require('/opt/domjudge/domserver/etc/domserver-static.php');
 
 define('SCRIPT_ID', 'balloons');
 define('LOGFILE', LOGDIR.'/balloons.log');
 
-require(LIBDIR . '/init.php');
+require(LIBDIR . '/lib.error.php');
+require(LIBDIR . '/lib.misc.php');
 
-setup_database_connection();
+$verbose = LOG_INFO;
+
+define('WAITTIME', 5);
+
+function usage() : void
+{
+    echo "Usage: " . SCRIPT_ID . " API_LOCATION\n" .
+        "Send out notifications on each new balloon.\n\n" .
+        "This script is not needed when using the web interface to handle balloons.\n\n" .
+        "API_LOCATION is the base of your DOMjudge installation, without the\n" .
+        "'/api' auffix and no trailing slash, e.g. https://example.org/domjudge\n\n" .
+        "Credentials for this API need to be in a .netrc file in your home directory,\n" .
+        "please refer to the DOMjudge manual for the format.\n\n";
+        "The way to notify is configured inside this script by setting BALLOON_CMD.\n\n";
+    exit;
+}
 
 require __DIR__ ."/vendor/autoload.php";
 use Mike42\Escpos\Printer;
 use Mike42\Escpos\PrintConnectors\FilePrintConnector;
 
 require_once 'Util.php';
-$verbose = LOG_INFO;
-
-$waittime = 5;
-
 /**
  * Returns a text to be sent when notifying of a new balloon.
  */
-function notification_text($team, $problem, $contest, $probs_solved, $probs_data, $comment)
+function notification_text(array $contest, string $teamname, ?string $location,
+    string $problem, string $color, array $probs_solved, string $comment = null) : string
 {
     $ret =  "\n".     
-        (empty($team['room']) ? "" : "位置: ".$team['room']."\n") .
-        "比赛:".$contest['name']." (c".$contest['cid'].")\n".
-        "队伍:".$team['name']." (t".$team['teamid'].")\n".
-        "题目:".$probs_data[$problem]['shortname'].": ".$probs_data[$problem]['name'].
-        (empty($probs_data[$problem]['color']) ? "" :
-        " (".convertToColor($probs_data[$problem]['color']).")") . "\n\n" .
+        "A problem has been solved:\n".
+        "\n".
+        (empty($location) ? "" : "位置: ".$location."\n") .
+        "队伍:     ".$teamname."\n".
+        "比赛:  ".$contest['name']." (c".$contest['id'].")\n".
+        "题目:  ".$problem.
+        (empty($color) ? "" : " (colour: ".$color.")") . "\n\n" .
         "本队当前气球状态:\n";
 
-    foreach ($probs_solved as $probid) {
-        $ret .= " - " . $probs_data[$probid]['shortname'] .": " . $probs_data[$probid]['name'] .
-        (empty($probs_data[$probid]['color']) ? "" :
-        " (".convertToColor($probs_data[$probid]['color']).")") . "\n";
-    }
-
-    if ($comment) {
-        $ret .= "\n$comment\n";
-    }
+        foreach ($probs_solved as $probid => $color) {
+            $ret .= " - " . $probid . " (colour: " . convertToColor($color['rgb']) . ")\n";
+        }
+    
+        if ($comment) {
+            $ret .= "\nNOTE: $comment\n";
+        }
 
     return $ret;
 }
 
-$cids = array();
-$cdatas = array();
-$nonfirst_contest = array();
-$nonfirst_problem = array();
-$nonfirst_team = array();
-$infreeze = false;
+function setup_curl_handle()
+{
+    $curl_handle = curl_init();
+    curl_setopt($curl_handle, CURLOPT_USERAGENT, "balloons from DOMjudge/" . DOMJUDGE_VERSION);
+    curl_setopt($curl_handle, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($curl_handle, CURLOPT_NETRC, true);
+    curl_setopt($curl_handle, CURLOPT_RETURNTRANSFER, true);
+    return $curl_handle;
+}
+
+function close_curl_handle($handle) : void
+{
+    curl_close($handle);
+}
+
+function request($curl_handle, string $API, string $url, string $verb = 'GET', string $data = '') : string
+{
+    $url = $API . "/" . $url;
+    if ($verb == 'GET') {
+        $url .= '?' . $data;
+    }
+
+    curl_setopt($curl_handle, CURLOPT_URL, $url);
+
+    curl_setopt($curl_handle, CURLOPT_CUSTOMREQUEST, $verb);
+    curl_setopt($curl_handle, CURLOPT_HTTPHEADER, []);
+    if ($verb == 'POST') {
+        curl_setopt($curl_handle, CURLOPT_POST, true);
+        if (is_array($data)) {
+            curl_setopt($curl_handle, CURLOPT_HTTPHEADER, ['Content-Type: multipart/form-data']);
+        }
+    } else {
+        curl_setopt($curl_handle, CURLOPT_POST, false);
+    }
+    if ($verb == 'POST' || $verb == 'PUT') {
+        curl_setopt($curl_handle, CURLOPT_POSTFIELDS, $data);
+    } else {
+        curl_setopt($curl_handle, CURLOPT_POSTFIELDS, null);
+    }
+
+    $response = curl_exec($curl_handle);
+    if ($response === false) {
+        $errstr = "Error while executing curl $verb to url " . $url . ": " . curl_error($curl_handle);
+        error($errstr);
+    }
+    $status = curl_getinfo($curl_handle, CURLINFO_HTTP_CODE);
+    if ($status < 200 || $status >= 300) {
+        if ($status == 401) {
+            $errstr = "Authentication failed (error $status) while contacting $url. " .
+                "Check credentials in ~/.netrc.";
+        } else {
+            $errstr = "Error while executing curl $verb to url " . $url .
+                ": http status code: " . $status .
+                ", request size = " . strlen($data) .
+                ", response: " . $response;
+        }
+        error($errstr);
+    }
+
+    return $response;
+}
+
+if ($argc <= 1) {
+    usage();
+    exit;
+}
+
+$API = $argv[1] . '/api/v4';
 
 logmsg(LOG_NOTICE, "Balloon notifications started [DOMjudge/".DOMJUDGE_VERSION."]");
 
 initsignals();
+
+$curl_handle = setup_curl_handle();
+
+$cids = [];
+$cdatas = [];
 
 // Constantly check database for new correct submissions
 while (true) {
@@ -79,11 +167,15 @@ while (true) {
     }
     if ($exitsignalled) {
         logmsg(LOG_NOTICE, "Received signal, exiting.");
+        close_curl_handle($curl_handle);
         exit;
     }
 
-    $newcdatas = getCurContests(true);
-    $newcids = array_keys($newcdatas);
+    $newcdatas = dj_json_decode(request($curl_handle, $API, 'contests', 'GET', 'onlyActive=true'));
+    $newcids = [];
+    foreach($newcdatas as $cdata) {
+        $newcids[] = $cdata['id'];
+    }
     $oldcids = $cids;
     $oldcidsstring = "none";
     if (!empty($oldcids)) {
@@ -105,124 +197,66 @@ while (true) {
         $cdatas = $newcdatas;
     }
 
-    foreach ($cdatas as $cid => $cdata) {
-        if (isset($cdata['freezetime']) && !$infreeze &&
-            difftime(now(), (float)$cdata['freezetime']) >= 0) {
-            $infreeze = true;
-            logmsg(
-                LOG_NOTICE,
-                   "Scoreboard of contest c${cid} is frozen since " .
-                   $cdata['freezetime']
-            );
+    foreach ($cdatas as $cdata) {
+        $API_balloons = 'contests/' . urlencode($cdata['id']) . '/balloons';
+        $rows = dj_json_decode(request($curl_handle, $API, $API_balloons, 'GET', 'todo=true'));
+        foreach($rows as $row) {
+            logmsg(LOG_DEBUG, "New problem solved: " . $row['problem'] .
+                              " by team " . $row['team'] .
+                              " for contest c" . $cdata['id']);
+
+            logmsg(LOG_INFO, "Sending notification:" .
+                   " team " . $row['team'] .
+                   ", problem " . $row['problem'] .
+                   ", contest c" . $cdata['id'] . ".");
+
+            try {
+                // Enter the device file for your USB printer here
+                $connector = new FilePrintConnector("php://stdout");
+                // $connector = new FilePrintConnector("/dev/usb/lp0");
+                // $connector = new FilePrintConnector("/dev/usb/lp1");
+                // $connector = new FilePrintConnector("/dev/usb/lp2");
+                
+                $printer = new Printer($connector);
+
+                $printer ->initialize();
+
+                $printer -> setJustification(Printer::JUSTIFY_CENTER);
+                $printer -> selectPrintMode(Printer::MODE_DOUBLE_HEIGHT | Printer::MODE_DOUBLE_WIDTH);
+                
+                $printer -> textChinese("气球运输单\n");
+                $printer -> feed(1);
+                $printer -> textChinese("编号:".$row['balloonid']."\n");
+                $printer -> feed(1);
+                $printer -> textChinese(
+                    (empty($team['room']) ? "" : $team['room'])." ".
+                    convertToColor($row['contestproblem']['rgb'])."\n"
+                );
+                $printer -> feed(1);
+
+                $printer -> setJustification();
+                $printer -> selectPrintMode();
+
+                $printer -> textChinese(notification_text(
+                    $cdata,
+                    $row['team'],
+                    $row['location'],
+                    $row['problem'],
+                    convertToColor($row['contestproblem']['rgb']),
+                    $row['total'],
+                    $row['awards']
+                ));
+                
+                $printer -> text("--------------------------------\n");
+                $printer -> feed(3);   
+            } catch (Exception $e) {
+                warning("Couldn't print error: ". $e ->getMessage() . "\n");
+            } finally {
+                // request($curl_handle, $API, $API_balloons . '/' . urlencode((string)$row['balloonid']) . '/done', 'POST');
+            }
+
         }
-        $freezecond = '';
-        if (!dbconfig_get('show_balloons_postfreeze', 0) &&
-            isset($cdata['freezetime'])) {
-            $freezecond = 'AND submittime < "' . $cdata['freezetime'] . '"';
-        }
-
-        do {
-            $res = $DB->q("SELECT b.*, s.probid, s.submittime,
-                           t.teamid, t.name AS teamname, t.room, c.name AS catname
-                           FROM balloon b
-                           LEFT JOIN submission s USING (submitid)
-                           LEFT JOIN team t USING (teamid)
-                           LEFT JOIN team_category c USING (categoryid)
-                           WHERE s.cid = %i AND b.printed = 0 AND c.visible = 1 $freezecond
-                           ORDER BY submitid ASC", $cid);
-
-            while ($row = $res->next()) {
-                $team = array('name' => $row['teamname'],
-                          'room' => $row['room'],
-                          'teamid' => $row['teamid']);
-
-                logmsg(LOG_DEBUG, "New problem solved: p" . $row['probid'] .
-                                  " by team t" . $row['teamid'] .
-                                  " for contest c" . $cid);
-
-                // if (defined('BALLOON_CMD') && BALLOON_CMD) {
-                    $probs_solved = $DB->q('COLUMN SELECT probid FROM scorecache
-                                            WHERE cid = %i AND teamid = %i AND is_correct_restricted = 1',
-                                           $cid, $row['teamid']);
-                    $probs_data = $DB->q('KEYTABLE SELECT probid AS ARRAYKEY,shortname,name,color
-                                          FROM problem LEFT JOIN contestproblem USING(probid) WHERE cid = %i', $cid);
-
-                    // current limitation is that this gets reset if the balloon daemon is restarted
-                    $comment = '';
-                    if (!isset($nonfirst_contest[$cid])) {
-                        $comment = '全场第一个通过题目';
-                        $nonfirst_contest[$cid] = true;
-                    } else {
-                        if (!isset($nonfirst_problem[$cid]) || !isset($nonfirst_problem[$cid][$row['probid']])) {
-                            $comment = '全场第一个通过此题';
-                            $nonfirst_problem[$cid][$row['probid']] = true;
-                        }
-                        
-                        if (!isset($nonfirst_team[$cid]) && !isset($nonfirst_team[$cid][$row['teamid']])) {
-                            $comment = '队伍通过的第一道题';
-                            $nonfirst_team[$cid][$row['teamid']] = true;
-                        }
-                        
-                    }
-
-                    logmsg(LOG_INFO, "Sending notification:" .
-                           " team t" .$row['teamid'] .
-                           ", problem p" . $row['probid'] .
-                           ", contest c" . $cid . ".");
-
-                    logmsg(LOG_DEBUG, "Running command: '" . BALLOON_CMD . "'");
-
-                    
-                    try {
-                        // Enter the device file for your USB printer here
-                        // $connector = new FilePrintConnector("php://stdout");
-                        $connector = new FilePrintConnector("/dev/usb/lp0");
-                        // $connector = new FilePrintConnector("/dev/usb/lp1");
-                        // $connector = new FilePrintConnector("/dev/usb/lp2");
-                        
-                        $printer = new Printer($connector);
-
-                        $printer ->initialize();
-
-                        $printer -> setJustification(Printer::JUSTIFY_CENTER);
-                        $printer -> selectPrintMode(Printer::MODE_DOUBLE_HEIGHT | Printer::MODE_DOUBLE_WIDTH);
-                        
-                        $printer -> textChinese("气球运输单\n");
-                        $printer -> feed(1);
-                        $printer -> textChinese("编号:".$row['balloonid']."\n");
-                        $printer -> feed(1);
-                        $printer -> textChinese(
-                            (empty($team['room']) ? "" : $team['room'])." ".
-                            (empty($probs_data[$row['probid']]['color']) ? "" :
-                            convertToColor($probs_data[$row['probid']]['color']))."\n"
-                        );
-                        $printer -> feed(1);
-
-                        $printer -> setJustification();
-                        $printer -> selectPrintMode();
-
-                        $printer -> textChinese(notification_text(
-                            $team,
-                            $row['probid'],
-                            $cdata,
-                            $probs_solved,
-                            $probs_data,
-                            $comment
-                        ));
-                        
-                        $printer -> text("--------------------------------\n");
-                        $printer -> feed(3);          
-                        
-                    } catch (Exception $e) {
-                        warning("Couldn't print to this printer: ". $e ->getMessage() . "\n");
-                    } finally {
-                        $DB->q('UPDATE balloon SET printed=1 WHERE balloonid = %i', $row['balloonid']);
-                        $printer -> close();
-                    }
-                }
-            // }
-        } while ($res->count() != 0);
     }
 
-    sleep($waittime);
+    sleep(WAITTIME);
 }

--- a/main.php
+++ b/main.php
@@ -23,13 +23,11 @@ if (isset($_SERVER['REMOTE_ADDR'])) {
     die("Commandline use only");
 }
 
-require('/opt/domjudge/domserver/etc/domserver-static.php');
-
 define('SCRIPT_ID', 'balloons');
-define('LOGFILE', LOGDIR.'/balloons.log');
+define('LOGFILE', 'balloons.log');
 
-require(LIBDIR . '/lib.error.php');
-require(LIBDIR . '/lib.misc.php');
+require_once('lib/lib.error.php');
+require_once('lib/lib.misc.php');
 
 $verbose = LOG_INFO;
 

--- a/main.php
+++ b/main.php
@@ -31,6 +31,7 @@ require_once('lib/lib.misc.php');
 
 $verbose = LOG_INFO;
 
+define('DOMJUDGE_VERSION', '8.1.4');
 define('WAITTIME', 5);
 
 function usage() : void
@@ -210,8 +211,8 @@ while (true) {
 
             try {
                 // Enter the device file for your USB printer here
-                $connector = new FilePrintConnector("php://stdout");
-                // $connector = new FilePrintConnector("/dev/usb/lp0");
+                // $connector = new FilePrintConnector("php://stdout");
+                $connector = new FilePrintConnector("/dev/usb/lp0");
                 // $connector = new FilePrintConnector("/dev/usb/lp1");
                 // $connector = new FilePrintConnector("/dev/usb/lp2");
                 
@@ -250,7 +251,8 @@ while (true) {
             } catch (Exception $e) {
                 warning("Couldn't print error: ". $e ->getMessage() . "\n");
             } finally {
-                // request($curl_handle, $API, $API_balloons . '/' . urlencode((string)$row['balloonid']) . '/done', 'POST');
+                request($curl_handle, $API, $API_balloons . '/' . urlencode((string)$row['balloonid']) . '/done', 'POST');
+                $printer -> close();
             }
 
         }


### PR DESCRIPTION
Domserver 8.x has no longer kept many database libs. Some apis are used instead. This version can run for domserver 8.x(tested on 8.1.4 only).

Get `/domjudge/api/v4/contests/<contest id>/balloons?onlyActive=true&todo=true` for a sample output.
